### PR TITLE
sunyu front&backend

### DIFF
--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -1,4 +1,5 @@
 {
+  "cloud": true,
   "pages": [
     "pages/index/index",
     "pages/userConsole/userConsole",

--- a/miniprogram/pages/category/category.js
+++ b/miniprogram/pages/category/category.js
@@ -48,50 +48,13 @@ Page({
       text: '其他'
     },
     ],
-    loading: 0,
+    loading: 1,
     goodsList: [],
     currentCategory: {},
     name: '',
     scrollLeft: 0,
     scrollTop: 0,
     scrollHeight: 0,
-  },
-
-  getCategoryInfo: function () {
-    let that = this;
-    let url = 'https://mobile.ximalaya.com/mobile/discovery/v3/recommend/hotAndGuess?code=43_310000_3100&device=android&version=5.4.45';
-    utils.request(url, { name: this.data.name })
-      .then(function (res) {
-
-        if (res.errno == 0) {
-          that.setData({
-            navList: res.data.brotherCategory,
-            currentCategory: res.data.tag
-          });
-
-          //nav位置
-          let currentIndex = 0;
-          let navListCount = that.data.navList.length;
-          for (let i = 0; i < navListCount; i++) {
-            currentIndex += 1;
-            if (that.data.navList[i].text == that.data.name) {
-              break;
-            }
-          }
-          if (currentIndex > navListCount / 2 && navListCount > 5) {
-            that.setData({
-              scrollLeft: currentIndex * 60
-            });
-          }
-          that.getGoodsList();
-
-        } else {
-          //显示错误信息
-        }
-        
-      });
-
-      
   },
 
   /**
@@ -114,18 +77,29 @@ Page({
       }
     });
 
-    this.getCategoryInfo();
+    this.getGoodsList();
   },
 
   getGoodsList: function () {
     var that = this;
-    url = 'https://mobile.ximalaya.com/mobile/discovery/v3/recommend/hotAndGuess?code=43_310000_3100&device=android&version=5.4.45';
-    util.request(url, {tag: that.data.text})
-      .then(function (res) {
-        that.setData({
-          goodsList: res.data.goodsList,
-        });
-      });
+    if (this.data.name){
+      wx.cloud.callFunction({
+        name: 'searchByTag',
+        data:{
+          tag: this.data.name,
+        },
+        success(res) {
+          console.log('成功', res.result.data);
+          that.setData({
+            loading: 0,
+            goodsList: res.result.data,
+          });
+        },
+      })
+    }
+    else{
+      console.log('全部');
+    }
   },
 
   switchCate: function(e) {
@@ -152,23 +126,22 @@ Page({
         }
         wx.setStorageSync('categoryId', text)
         this.setData({
-            name: text
+            name: text,
+            loading: 1,
         })
+        this.getGoodsList();
     }
 },
 
   /**
    * 生命周期函数--监听页面初次渲染完成
    */
-  onReady: function () {
-
-  },
+  onReady: function () {},
 
   /**
    * 生命周期函数--监听页面显示
    */
   onShow: function () {
-
   },
 
   /**

--- a/miniprogram/pages/category/category.wxml
+++ b/miniprogram/pages/category/category.wxml
@@ -7,33 +7,21 @@
             <view class="item {{ name == item.text?'active' : ''}}" wx:for="{{navList}}" wx:key="text" data-text="{{item.text}}" bindtap="switchCate">{{item.text}}</view>
         </scroll-view>
         <scroll-view class="cate" scroll-y="true" bindscrolltolower="onBottom">
-            <block wx:if="{{loading == 0}}">
-                <view class='banner-container' wx:if="{{nowId!= 0 && index_banner_img == 1}}">
-                    <image mode='aspectFill' style="width:100%;height:{{currentCategory.p_height}}rpx" src='{{currentCategory.img_url}}'>
-                    </image>
-                    <view class="bg" style="height:{{currentCategory.p_height}}rpx;line-height:{{currentCategory.p_height}}rpx;"></view>
-                    <view class="text" style="height:{{currentCategory.p_height}}rpx;line-height:{{currentCategory.p_height}}rpx;">{{currentCategory.name}}</view>
-                </view>
+            <block wx:if="{{loading == 0}}">          
                 <view class='list-wrap clearfix'>
-                    <view class="goods-box {{(index+1)%2 == 0?'no-margin':''}}" wx:for="{{list}}" wx:for-index="index" wx:for-item="item" wx:key="id">
-                        <navigator hover-class='none' class='navi-url' url="/pages/goods/goods?id={{item.id}}">
+                    <view class="goods-box {{(index+1)%2 == 0?'no-margin':''}}" wx:for="{{goodsList}}" wx:for-index="index" wx:for-item="item" wx:key="id">
+                        <navigator hover-class='none' class='navi-url' url="/pages/details/index">
                             <view class="box">
-                                <image src="{{item.list_pic_url}}" class="image">
+                                <image src="{{item.coverMiddle}}" class="image">
                                     <view wx:if="{{item.is_new == 1}}" class='new-tag'>新品</view>
                                 </image>
-                                <block wx:if="{{item.goods_number <= 0}}">
-                                    <!-- <view class='no-goods-mask'></view> -->
-                                    <view class='sold-img'>
-                                        <image class='soldout' src='/images/icon/sold-out.png'></image>
-                                    </view>
-                                </block>
                             </view>
-                            <view class="goods-info {{item.goods_number <= 0?'fast-out-status':''}}">
-                                <view class="goods-title">{{item.name}}</view>
-                                <view class="goods-intro">{{item.goods_brief}}</view>
+                            <view class="goods-info">
+                                <view class="goods-title">{{item.intro}}</view>
+                                <view class="goods-intro">{{item.desc}}</view>
                                 <view class='price-container'>
                                     <view class='l'>
-                                        <view class='h'>￥{{item.min_retail_price}}</view>
+                                        <view class='h'>￥{{item.price}}</view>
                                     </view>
                                 </view>
                             </view>

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -26,59 +26,7 @@ Page({
         text: '更多'
       },
     ],
-    goodsList: [{
-      id: '1',
-      coverMiddle: '/images/goods/01.jpg',
-      events: 'goToBangDan',
-      intro: '数字设计',
-      price: '￥15',
-      nums: '3',
-      seller: '草莓屁屁',
-      tag: '二手书籍',
-      desc: 'xxx',
-      comment: 'xxx',
-      date: 'xxxx-xx-xx'
-    },
-    {
-      id: '2',
-      coverMiddle: '/images/goods/02.jpg',
-      events: 'goToBangDan',
-      intro: '蓝牙耳机',
-      price: '￥360',
-      nums: '8',
-      seller: '奈寒',
-      tag: '数码产品',
-      desc: 'xxx',
-      comment: 'xxx',
-      date: 'xxxx-xx-xx'
-    },
-    {
-      id: '3',
-      coverMiddle: '/images/goods/03.jpg',
-      events: 'goToBangDan',
-      intro: '美宝莲卸妆水',
-      price: '￥69',
-      nums: '1',
-      seller: '豆',
-      tag: '护肤化妆',
-      desc: 'xxx',
-      comment: 'xxx',
-      date: 'xxxx-xx-xx'
-    },
-    {
-      id: '4',
-      coverMiddle: '/images/goods/04.jpg',
-      events: 'goToBangDan',
-      intro: '美宝莲口红',
-      price: '￥80',
-      nums: '4',
-      seller: '茜茜子',
-      tag: '护肤美妆',
-      desc: 'xxx',
-      comment: 'xxx',
-      date: 'xxxx-xx-xx'
-    },
-  ],
+    goodsList: [],
     swiperCurrent: 0,
   },
 
@@ -87,27 +35,17 @@ Page({
    */
   onLoad: function (options) {
     var that = this;
-    var url = 'https://mobile.ximalaya.com/mobile/discovery/v3/recommend/hotAndGuess?code=43_310000_3100&device=android&version=5.4.45';
-
-    // 调用自己封装的工具函数，在utils中
-    utils.myRequest({
-      url: url,
-      methods: 'GET',
-      success: function(result){
-        that.setData({
-          showitem: true,
-          guess: result.data.paidArea.list,
-          xiaoshuocontent: result.data.hotRecommends.list[0].list,
-          xiangshengcontent: result.data.hotRecommends.list[2].list,
-          lishicontent: result.data.hotRecommends.list[3].list
-        })
+    wx.cloud.callFunction({
+      name: 'latest8',
+      data:{
       },
-      fail: function() {
+      success(res) {
+        console.log('成功', res.result.data);
         that.setData({
-          showitem: false
-        })
-      }
-    });
+          goodsList: res.result.data,
+        });
+      },
+    })
   },
   // 宫格导航改变事件
   gotoFenlei(e) {

--- a/miniprogram/pages/search/search.js
+++ b/miniprogram/pages/search/search.js
@@ -13,21 +13,25 @@ Page({
     keyword:'',
     goodsList: [],
     showitem: false,
-    hotData:[
-      {intro:"数分",icon:"icon-jiantouUp",color:"text-orange"},
-      {intro:"airpods",icon:"icon-jiantouUp",color:"text-red"},
-      {intro:"卸妆水",icon:"icon-jiantouDown",color:"text-green"},
-      {intro:"编译课本",icon:"icon-jiantouUp",color:"text-red"},
-      {intro:"薯片",icon:"icon-jiantouDown",color:"text-green"},
-      {intro:"毛概",icon:"icon-jiantouUp",color:"text-red"},
-    ]
+    hotData:[]
   },
 
   /**
    * 生命周期函数--监听页面加载
    */
   onLoad: function (options) {
-
+    var that = this;
+    wx.cloud.callFunction({
+      name: 'keptTop6',
+      data:{
+      },
+      success(res) {
+        console.log('成功', res.result.data);
+        that.setData({
+          hotData: res.result.data,
+        });
+      },
+    })
   },
 
   onShow:function(){
@@ -40,10 +44,6 @@ Page({
   },
 
   onHide:function(){
-    console.log('search is onHide')
-    wx.redirectTo({
-        url: '../search/search'
-    })
   },
 
   goBack: function(){
@@ -109,5 +109,17 @@ Page({
     }else{
       console.log('未输入任何字符')
     }
+  },
+
+  // 上新推荐改变事件
+  gotoDetails(e) {
+    var url = e.currentTarget.dataset.coverimg;
+    var title = e.currentTarget.dataset.title;
+    //wx.navigateTo({
+    //  url: '/pages/details/details?url=' + url + '&title=' + title,
+    //})
+    wx.navigateTo({
+      url: '/pages/details/index'
+    })
   }
 })

--- a/miniprogram/pages/search/search.wxml
+++ b/miniprogram/pages/search/search.wxml
@@ -16,11 +16,10 @@
   </view>
   <view class="hmly-hot-content">
     <view class="hmly-hot-items" wx:for="{{hotData}}" wx:key="index">
-      <view class="hmly-item-left">
+      <view class="hmly-item-left" bindtap="gotoDetails">
         <view class="{{index<3 ? 'text-red' : ''}}">{{index+1}}</view>
         <view class="hmly-item-title text-black">{{item.intro}}</view>
       </view>
-      <text class="{{item.icon}} {{item.color}}"></text>
     </view>
   </view>
 </view>


### PR DESCRIPTION
前后联调：
首页“二手上新”——按照商品上架时间排列
搜索“热门搜索”——按照收藏数排序，点击搜索条目可以跳转到详情页
分类——对应标签商品显示（全部条目未实现），点击商品跳转到详情页